### PR TITLE
Fix static state wrong reset

### DIFF
--- a/Assets/PlaygamaBridge/Scripts/Bridge.cs
+++ b/Assets/PlaygamaBridge/Scripts/Bridge.cs
@@ -10,7 +10,6 @@ using Playgama.Modules.Player;
 using Playgama.Modules.RemoteConfig;
 using Playgama.Modules.Social;
 using Playgama.Modules.Storage;
-using UnityEngine;
 
 namespace Playgama
 {
@@ -58,8 +57,7 @@ namespace Playgama
         }
 
 #if UNITY_EDITOR
-        [RuntimeInitializeOnLoadMethod]
-        private static void ResetOnLoad()
+        private void OnDestroy()
         {
             _instance = null;
             _isApplicationQuitting = false;


### PR DESCRIPTION
# Issue
`Bridge.cs` uses `[RuntimeInitializeOnLoadMethod]` to reset it's static state. The issue is that it happens after it's own `Awake()` so state is being cleared right after initialization. On the next run without domain reload (which is often disable by unity devs for rapid developing) `Bridge.cs` still have it's `_isApplicationQuitting: true` which cause returning `null` by `instance` property.

> In my particular case it breaks initialization of my project after first run.

# What is changed
Instead of clear static state "before" something happens I think it is better to clear it in the "end" of run, so I've put logic into simple `Bridge.OnDestroy()`.

