### PR TITLE
Add legacy Unity support (2021.3)

### DIFF
--- a/Editor/Bridge/BridgeWindow.cs
+++ b/Editor/Bridge/BridgeWindow.cs
@@ -16,7 +16,7 @@ namespace Playgama.Editor
         private const float TabColumnWidth = 150f;
 
         // Project-specific settings file
-        private static readonly string SettingsFilePath = Path.Combine(Application.dataPath, "../Library/PlaygamaBridge.settings");
+        private static string SettingsFilePath;
 
         // Tab indices for external navigation
         public const int TabHome = 0;
@@ -41,6 +41,7 @@ namespace Playgama.Editor
 
         private void OnEnable()
         {
+            SettingsFilePath = Path.Combine(Application.dataPath, "../Library/PlaygamaBridge.settings");
             wantsMouseMove = true;
 
             _buildInfo = new BuildInfo();
@@ -125,7 +126,7 @@ namespace Playgama.Editor
 
             Repaint();
         }
-        
+
         public void SetSelectedTab(int tabIndex)
         {
             if (tabIndex < 0 || tabIndex >= _tabs.Count)

--- a/Runtime/Scripts/Common/Singleton.cs
+++ b/Runtime/Scripts/Common/Singleton.cs
@@ -19,7 +19,11 @@ namespace Playgama.Common
                     return _instance;
                 }
 
+#if UNITY_2023_1_OR_NEWER
                 _instance = FindFirstObjectByType<T>();
+#else
+                _instance = FindObjectOfType<T>();
+#endif
                 if (_instance != null)
                 {
                     return _instance;


### PR DESCRIPTION
Small tweaks to make it work again with older versions of Unity.

Other than that, it has works nicely after all these years on a legacy project. Easy to port from IGB to Playgama.

Can confirm WebGL build works properly on Unity 2021.3 project just like IGB was.

Thanks!